### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rdowavic/kubelint-1
+module github.com/CoverGenius/kubelint
 
 go 1.13
 


### PR DESCRIPTION
CoverGenius/kubelint should be declared as CoverGenius/kubelint rather than the fork rdowavic/kubelint-1